### PR TITLE
limits which entries we evaluate to those where the context is platformsh

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ runs:
         while (( counter < numberOfSteps )) && [[ -z "${target_url}" ]]; do
             sleep ${{ inputs.delay-in-seconds }}
         
-            target_url=$(gh api "${statusLocation}" | jq -r 'map(select(.state | contains("success"))) | .[] .target_url' )
+            target_url=$(gh api "${statusLocation}" | jq -r '.[] | select(.context | (contains("platformsh") or contains("upsun"))) | select(.state | contains("success")) | .target_url' )
             printf "Attempt %d of %d.\n" "${counter}" "${numberOfSteps}"
             counter=$((++counter))
         done


### PR DESCRIPTION
or upsun. closes #8 